### PR TITLE
Feature/past events query param

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,11 @@ UPDATE users SET is_banned = true WHERE uuid='D47DA01C-51BB-4F96-90B6-D64B77225E
 
 > List events
 
+Query parameters:
+
+* `cityId` Integer. If specified, returns only events in the city with given id.
+* `showPast` Boolean. Should events that have ended also be returned. Defaults to false.
+
 Responses:
 
 * `200 OK` List of [event objects](#event-object).

--- a/src/http/event-http.js
+++ b/src/http/event-http.js
@@ -21,6 +21,7 @@ const getEvents = createJsonRoute(function(req, res) {
   const eventParams = assert({
     id: req.params.id,
     city: req.query.cityId,
+    showPast: req.query.showPast,
   }, 'eventsParams');
 
   const coreParams = _.merge(eventParams, {

--- a/src/validation/index.js
+++ b/src/validation/index.js
@@ -68,6 +68,7 @@ const schemas = {
   eventsParams: {
     city: common.primaryKeyId,
     id: common.primaryKeyId,
+    showPast: Joi.boolean().default(false),
   },
 
   citiesParams: {

--- a/src/validation/index.js
+++ b/src/validation/index.js
@@ -90,18 +90,18 @@ function assert(obj, schemaName) {
   var expected = {};
   expected[schemaName] = joiObj;
 
-  try {
-    Joi.assert(content, expected);
-  } catch (err) {
-    if (!err.isJoi) {
-      throw err;
+  var result = Joi.validate(content, expected);
+
+  if (result.error) {
+    if (!result.error.isJoi) {
+      throw result.error;
     }
 
-    _throwJoiError(err);
-  };
+    _throwJoiError(result.error);
+  }
 
   // Return for convenience
-  return obj;
+  return result.value[schemaName];
 }
 
 // Converts string `value` to a correct js object.


### PR DESCRIPTION
- Added query param `showPast` for `/events` which filters out events that have ended.
- Fixed `assert()`. Previously the function returned the given object parameter. Now it returns the validated object instead, making defining default values possible.