### PR TITLE
Feature/score adjustments

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,3 @@
 web: NODE_ENV=production ./node_modules/.bin/babel-node --presets es2015 ./src/index.js
 event-worker: NODE_ENV=production node_modules/.bin/babel-node --presets es2015 ./src/worker/fetch-events.js
+bias-worker: NODE_ENV=production node_modules/.bin/babel-node --presets es2015 ./src/worker/recalculate-biases.js

--- a/migrations/20170314082605_add_radio_table.js
+++ b/migrations/20170314082605_add_radio_table.js
@@ -12,7 +12,7 @@ exports.up = function(knex, Promise) {
       .inTable('cities')
       .onDelete('CASCADE')
       .onUpdate('CASCADE');
-  })
+  });
 };
 
 exports.down = function(knex, Promise) {

--- a/migrations/20170407075206_adjust_action_type_scores.js
+++ b/migrations/20170407075206_adjust_action_type_scores.js
@@ -1,0 +1,14 @@
+
+exports.up = function(knex, Promise) {
+  return knex.raw(`
+    ALTER TABLE action_types
+    ALTER COLUMN value TYPE decimal(10, 4);
+  `);
+};
+
+exports.down = function(knex, Promise) {
+  return knex.raw(`
+    ALTER TABLE action_types
+    ALTER COLUMN value TYPE integer;
+  `);
+};

--- a/migrations/20170407090713_user_voting_bias_table.js
+++ b/migrations/20170407090713_user_voting_bias_table.js
@@ -1,0 +1,31 @@
+
+exports.up = function(knex, Promise) {
+  return knex.schema.createTable('voter_biases', function(table) {
+    table.increments('id').primary().index();
+    table.float('bias').notNullable().defaultTo(0.0);
+
+    table.integer('team_id').unsigned().notNullable().index();
+    table.foreign('team_id')
+      .references('id')
+      .inTable('teams')
+      .onDelete('CASCADE')
+      .onUpdate('CASCADE');
+
+    table.integer('user_id').unsigned().notNullable().index();
+    table.foreign('user_id')
+      .references('id')
+      .inTable('users')
+      .onDelete('CASCADE')
+      .onUpdate('CASCADE');
+  })
+  .raw(`
+    CREATE UNIQUE INDEX
+      only_one_bias_per_team
+    ON
+      voter_biases(user_id, team_id)
+  `);
+};
+
+exports.down = function(knex, Promise) {
+  return knex.schema.dropTable('voter_biases');
+};

--- a/migrations/20170410094328_weighted_wilsons.js
+++ b/migrations/20170410094328_weighted_wilsons.js
@@ -1,0 +1,34 @@
+// http://www.evanmiller.org/how-not-to-sort-by-average-rating.html
+exports.up = function(knex, Promise) {
+  return knex.schema.raw(`
+      CREATE FUNCTION wilsons(ups numeric, downs numeric) RETURNS numeric LANGUAGE plpgsql IMMUTABLE AS $$
+      DECLARE
+        z numeric;
+        n numeric;
+        p numeric;
+        l numeric;
+        r numeric;
+        u numeric;
+      BEGIN
+        n := ups + downs;
+        IF
+          n = 0
+        THEN
+          return 0;
+        END IF;
+        z := 1.281551565545;
+        p := ups::numeric / n;
+        l := p + 1 / ( 2 * n) * z * z;
+        r := z * sqrt(p * (1 - p) / n + z * z / (4 * n * n));
+        u := 1 + 1 / n * z * z;
+        RETURN ((l - r) / u);
+      END
+      $$;
+    `);
+};
+
+exports.down = function(knex, Promise) {
+  return knex.schema.raw(`
+      DROP FUNCTION wilsons(ups numeric, downs numeric)
+    `);
+};

--- a/migrations/20170411094607_ip_for_votes.js
+++ b/migrations/20170411094607_ip_for_votes.js
@@ -1,0 +1,12 @@
+
+exports.up = function(knex, Promise) {
+  return knex.schema.table('votes', function(table) {
+    table.string('ip', 30);
+  });
+};
+
+exports.down = function(knex, Promise) {
+  return knex.schema.table('votes', function(table) {
+    table.dropColumn('ip');
+  });
+};

--- a/seeds/action_types.js
+++ b/seeds/action_types.js
@@ -13,7 +13,7 @@ exports.seed = function(knex, Promise) {
       id: 2,
       code: 'SIMA',
       name: 'Grab a sima',
-      value: 1,
+      value: 0.1,
       cooldown: 5 * 60 * 1000
     });
   })

--- a/src/app.js
+++ b/src/app.js
@@ -9,6 +9,7 @@ import errorLogger from './middleware/error-logger';
 import requireClientHeaders from './middleware/require-client-headers';
 import requireApiToken from './middleware/require-api-token';
 import * as throttleCore from './core/throttle-core';
+import * as teamCore from './core/team-core';
 import * as fb from './util/fb';
 import * as feedAggregator from './worker/feed-aggregator';
 
@@ -75,6 +76,7 @@ function createApp() {
 
   // Initialize internal stuff
   throttleCore.initialize();
+  teamCore.initialize();
   fb.initialize();
   feedAggregator.start();
 

--- a/src/core/bias-core.js
+++ b/src/core/bias-core.js
@@ -3,7 +3,7 @@ import BPromise from 'bluebird';
 const {knex} = require('../util/database').connect();
 
 
-const calculateBias = (opts) => {
+const calculateBias = opts => {
   const wilsonsSql = `
     SELECT
       wilsons(
@@ -11,9 +11,9 @@ const calculateBias = (opts) => {
         COUNT(CASE votes.value WHEN -1 THEN 1 ELSE null END)::numeric
       )
     FROM votes
-    LEFT JOIN feed_items ON feed_items.id = votes.feed_item_id
-    LEFT JOIN users ON users.id = feed_items.user_id
-    LEFT JOIN teams ON teams.id = users.team_id
+    JOIN feed_items ON feed_items.id = votes.feed_item_id
+    JOIN users ON users.id = feed_items.user_id
+    JOIN teams ON teams.id = users.team_id
     WHERE votes.user_id = ? AND teams.id = ?
   `;
 

--- a/src/core/bias-core.js
+++ b/src/core/bias-core.js
@@ -1,0 +1,65 @@
+import _ from 'lodash';
+import BPromise from 'bluebird';
+const {knex} = require('../util/database').connect();
+
+const calculateBias = (opts) => {
+  const wilsonsSql = `
+    SELECT
+      wilsons(
+        COUNT(CASE votes.value WHEN 1 THEN 1 ELSE null END)::int,
+        COUNT(CASE votes.value WHEN -1 THEN -1 ELSE null END)::int
+      )
+    FROM votes
+    LEFT JOIN feed_items ON feed_items.id = votes.feed_item_id
+    LEFT JOIN users ON users.id = feed_items.user_id
+    WHERE votes.user_id = ? AND users.team_id = ?
+  `;
+
+  const upsertSql = `
+    WITH upsert AS
+      (UPDATE voter_biases
+      SET bias = ?
+      WHERE user_id = ? AND team_id = ?
+      RETURNING *
+    ), inserted AS (
+      INSERT INTO voter_biases(bias, user_id, team_id)
+      SELECT ?, ?, ?
+      WHERE NOT EXISTS( SELECT * FROM upsert )
+      RETURNING *
+    )
+    SELECT *
+    FROM upsert
+    UNION ALL
+    SELECT *
+    FROM inserted;
+  `;
+
+  const trx = opts.trx || knex;
+  const wilsonsParams = [
+    opts.userId,
+    opts.teamId,
+  ];
+
+  return trx.raw(wilsonsSql, wilsonsParams)
+    .then(results => {
+      const wilsons = _.get(results, 'rows[0].wilsons', null);
+      return _biasCoefficient(wilsons);
+    })
+    .then(bias => {
+      const upsertParams = [
+        bias, opts.userId, opts.teamId,
+        bias, opts.userId, opts.teamId,
+      ];
+
+      return trx.raw(upsertSql, upsertParams);
+    })
+};
+
+const _biasCoefficient = wilsons => BPromise.resolve(wilsons
+  ? 1 - Math.abs(wilsons - 0.5) / 0.5
+  : 0
+);
+
+export {
+  calculateBias,
+};

--- a/src/core/team-core.js
+++ b/src/core/team-core.js
@@ -37,6 +37,8 @@ function getTeams(opts) {
     FROM teams
     LEFT JOIN actions ON teams.id = actions.team_id ${isBanned ? '' : 'AND NOT actions.is_banned'}
     LEFT JOIN action_types ON actions.action_type_id = action_types.id
+    LEFT JOIN users ON users.id = actions.user_id
+    WHERE NOT users.is_banned
     GROUP BY teams.id)
   `;
 

--- a/src/core/team-core.js
+++ b/src/core/team-core.js
@@ -14,14 +14,16 @@ function getTeams(opts) {
         wilsons(
           SUM(CASE votes.value WHEN 1 THEN (1 - voter_biases.bias) ELSE null END)::numeric,
           SUM(CASE votes.value WHEN -1 THEN voter_biases.bias ELSE null END)::numeric
-        )
-        AS value,
+        ) AS value,
         users.team_id AS team_id
-      FROM feed_items
+      FROM (
+        SELECT feed_items.*
+        FROM feed_items
+        JOIN users ON users.id = feed_items.user_id AND NOT users.is_banned
+      ) feed_items
       JOIN users ON users.id = feed_items.user_id
       LEFT JOIN votes ON votes.feed_item_id = feed_items.id
       JOIN voter_biases ON voter_biases.user_id = votes.user_id AND voter_biases.team_id = users.team_id
-      WHERE NOT users.is_banned
       GROUP BY feed_items.id, users.team_id
     ) AS sub_query
     GROUP BY team_id)
@@ -30,26 +32,23 @@ function getTeams(opts) {
   const actionScoreSql = `
     (SELECT
       SUM(COALESCE(action_types.value, 0)) AS value,
-      teams.id AS team_id,
-      teams.name AS team_name,
-      teams.image_path AS image_path,
-      teams.city_id AS city_id
+      teams.id AS team_id
     FROM teams
     LEFT JOIN actions ON teams.id = actions.team_id ${isBanned ? '' : 'AND NOT actions.is_banned'}
     LEFT JOIN action_types ON actions.action_type_id = action_types.id
-    LEFT JOIN users ON users.id = actions.user_id
-    WHERE NOT users.is_banned
+    LEFT JOIN users ON users.id = actions.user_id AND NOT users.is_banned
     GROUP BY teams.id)
   `;
 
   let sqlString = `
     SELECT
-      actions_score.team_id AS id,
-      actions_score.team_name AS name,
-      actions_score.image_path AS image_path,
+      teams.id AS id,
+      teams.name AS name,
+      teams.image_path AS image_path,
       (COALESCE(actions_score.value, 0) + COALESCE(vote_score.value, 0))::int AS score,
-      actions_score.city_id AS city
-    FROM ${ actionScoreSql } AS actions_score
+      teams.city_id AS city
+    FROM teams
+    LEFT JOIN ${ actionScoreSql } actions_score ON actions_score.team_id = teams.id
     LEFT JOIN ${ voteScoreSql } vote_score ON vote_score.team_id = actions_score.team_id
   `;
 
@@ -57,7 +56,7 @@ function getTeams(opts) {
   let whereClauses = [];
 
   if (opts.city) {
-    whereClauses.push('actions_score.city_id = ?');
+    whereClauses.push('teams.city_id = ?');
     params.push(opts.city);
   }
 

--- a/src/core/team-core.js
+++ b/src/core/team-core.js
@@ -42,6 +42,13 @@ function _isUpdating() {
     .then(isUpdating => isUpdating == 'true');
 }
 
+/**
+ * Updates the cache if no update is in progress. Otherwise does nothing.
+ *
+ * To note is that checking for on going update is best effort only. Overlapping
+ * updates are possible, but should be very uncommon and not impact the
+ * generated cache in a negative way.
+ **/
 function _updateCache() {
   const update = redisClient.setAsync(KEY_IS_UPDATING, 'true')
     .then(() => knex('cities').select('*')

--- a/src/core/vote-core.js
+++ b/src/core/vote-core.js
@@ -55,8 +55,10 @@ function createOrUpdateVote(opts) {
             ])
         )
         .then(result => biasCore.calculateBias({
-          userId: opts.client.id,
-          teamId: _.get(result, 'rows[0].team_id', null),
+          rows: [{
+            userId: opts.client.id,
+            teamId: _.get(result, 'rows[0].team_id', null),
+          }],
           trx: trx,
         }))
         .then(result => undefined)

--- a/src/core/vote-core.js
+++ b/src/core/vote-core.js
@@ -7,9 +7,9 @@ import _ from 'lodash';
 function createOrUpdateVote(opts) {
   const updateVoteSql = `
     WITH upsert AS
-      (UPDATE votes SET value = ? WHERE user_id = ? AND feed_item_id = ? RETURNING *)
-      INSERT INTO votes (value, user_id, feed_item_id)
-      SELECT ?, ?, ? WHERE NOT EXISTS (SELECT * FROM upsert)
+      (UPDATE votes SET value = ?, ip = ? WHERE user_id = ? AND feed_item_id = ? RETURNING *)
+      INSERT INTO votes (value, ip, user_id, feed_item_id)
+      SELECT ?, ?, ?, ? WHERE NOT EXISTS (SELECT * FROM upsert)
   `;
 
   const selectVotesSql = `
@@ -35,8 +35,10 @@ function createOrUpdateVote(opts) {
       WHERE feed_items.id = ?)
   `;
 
-  const updateVoteParams = [opts.value, opts.client.id, opts.feedItemId,
-    opts.value, opts.client.id, opts.feedItemId];
+  const updateVoteParams = [
+    opts.value, opts.ip, opts.client.id, opts.feedItemId,
+    opts.value, opts.ip, opts.client.id, opts.feedItemId,
+  ];
 
   return knex.transaction(function(trx) {
     return trx.raw(updateVoteSql, updateVoteParams)

--- a/src/http/vote-http.js
+++ b/src/http/vote-http.js
@@ -13,7 +13,7 @@ let putVote = createJsonRoute(function(req, res) {
     feedItemId: req.body.feedItemId,
   }, 'vote');
 
-  return voteCore.createOrUpdateVote(_.merge(vote, { client: req.client }));
+  return voteCore.createOrUpdateVote(_.merge(vote, { client: req.client, ip: req.ip }));
 });
 
 export {

--- a/src/worker/recalculate-biases.js
+++ b/src/worker/recalculate-biases.js
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+import BPromise from 'bluebird';
+import _ from 'lodash';
+import * as biasCore from '../core/bias-core';
+const {knex} = require('../util/database').connect();
+const logger = require('../util/logger')(__filename);
+
+let teams;
+
+_updateBiases()
+.then(() => {
+  logger.info('Biases updated');
+  process.exit();
+})
+.catch(err => {
+  logger.error('Updating biases errored', err);
+  process.exit(1);
+});
+
+function _updateBiases() {
+  logger.info('Beginning bias update');
+
+  return knex('teams').select('id').then(results => {
+    teams = results;
+
+    return knex('users').select('id');
+  })
+  .then(users => BPromise.each(users, user =>
+    BPromise.each(teams, team =>
+      biasCore.calculateBias({
+        userId: user.id,
+        teamId: team.id,
+      })
+      .then(() => {
+        logger.info('Row updated');
+      })
+    )
+  ));
+}

--- a/src/worker/recalculate-biases.js
+++ b/src/worker/recalculate-biases.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import BPromise from 'bluebird';
+import _ from 'lodash';
 import * as biasCore from '../core/bias-core';
 const {knex} = require('../util/database').connect();
 const logger = require('../util/logger')(__filename);
@@ -22,13 +22,13 @@ function _updateBiases() {
     .innerJoin('users', 'users.id', 'feed_items.user_id')
     .groupBy(['votes.user_id', 'users.team_id'])
     .orderBy('votes.user_id')
-    .then(rows => BPromise.each(rows, row =>
-      biasCore.calculateBias({
-        userId: row.user_id,
-        teamId: row.team_id,
+    .then(rows => biasCore.calculateBias({
+      rows: _.map(rows, row => {
+        return {
+          teamId: row.team_id,
+          userId: row.user_id,
+        }
       })
-      .then(() => {
-        logger.info('Row updated');
-      })
-    ));
+    }
+  ));
 }

--- a/src/worker/recalculate-biases.js
+++ b/src/worker/recalculate-biases.js
@@ -1,11 +1,9 @@
 #!/usr/bin/env node
 import BPromise from 'bluebird';
-import _ from 'lodash';
 import * as biasCore from '../core/bias-core';
 const {knex} = require('../util/database').connect();
 const logger = require('../util/logger')(__filename);
 
-let teams;
 
 _updateBiases()
 .then(() => {
@@ -19,21 +17,18 @@ _updateBiases()
 
 function _updateBiases() {
   logger.info('Beginning bias update');
-
-  return knex('teams').select('id').then(results => {
-    teams = results;
-
-    return knex('users').select('id');
-  })
-  .then(users => BPromise.each(users, user =>
-    BPromise.each(teams, team =>
+  return knex('votes').select(['votes.user_id', 'users.team_id'])
+    .innerJoin('feed_items', 'feed_items.id', 'votes.feed_item_id')
+    .innerJoin('users', 'users.id', 'feed_items.user_id')
+    .groupBy(['votes.user_id', 'users.team_id'])
+    .orderBy('votes.user_id')
+    .then(rows => BPromise.each(rows, row =>
       biasCore.calculateBias({
-        userId: user.id,
-        teamId: team.id,
+        userId: row.user_id,
+        teamId: row.team_id,
       })
       .then(() => {
         logger.info('Row updated');
       })
-    )
-  ));
+    ));
 }


### PR DESCRIPTION
As users tend to vote a team rather than good content, PR contains mechanisms for calculating user voting habit bias and factor this into to final scoring. As a result of more complex math and DB queries, returned results for /teams are cached for 10min.

Note that for /teams endpoint to work as intended, a single run of 'bias-worker' is required.