### PR TITLE
Feature/sort top

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,3 @@
 web: NODE_ENV=production ./node_modules/.bin/babel-node --presets es2015 ./src/index.js
 event-worker: NODE_ENV=production node_modules/.bin/babel-node --presets es2015 ./src/worker/fetch-events.js
+top-score-worker: NODE_ENV=production node_modules/.bin/babel-node --presets es2015 ./src/worker/update-top-scores.js

--- a/README.md
+++ b/README.md
@@ -319,12 +319,12 @@ Query parameters:
 * `cityId` Integer. If specified, returns only posts by users belonging to guilds based in the city with given id.
 * `type` String. If specified, only feed items of that type are returned. One of: 'IMAGE', 'TEXT'.
 * `since` String. ISO-8601 format timestamp. If specified, only feed items created after given timestamp are returned. Note: If no time zone is specified, UTC is assumed.
-* `after` Integer. If specified, offsets the returned list by given amount.
+* `offset` Integer. If specified, offsets the returned list by given amount.
 
 Examples:
 
 * Get 30 newest feed items: `GET /api/feed?limit=30`
-* Get top 5-20 images: `GET /api/feed?sort=top&limit=15&after=5&type=IMAGE`
+* Get top 5-20 images: `GET /api/feed?sort=top&limit=15&offset=5&type=IMAGE`
 * Load 20 more feed items: `GET /api/feed?beforeId=123&limit=20`
 
     Assuming the id of oldest/last feed item client currently has is `123`.

--- a/README.md
+++ b/README.md
@@ -319,10 +319,12 @@ Query parameters:
 * `cityId` Integer. If specified, returns only posts by users belonging to guilds based in the city with given id.
 * `type` String. If specified, only feed items of that type are returned. One of: 'IMAGE', 'TEXT'.
 * `since` String. ISO-8601 format timestamp. If specified, only feed items created after given timestamp are returned. Note: If no time zone is specified, UTC is assumed.
+* `after` Integer. If specified, offsets the returned list by given amount.
 
 Examples:
 
 * Get 30 newest feed items: `GET /api/feed?limit=30`
+* Get top 5-20 images: `GET /api/feed?sort=top&limit=15&after=5&type=IMAGE`
 * Load 20 more feed items: `GET /api/feed?beforeId=123&limit=20`
 
     Assuming the id of oldest/last feed item client currently has is `123`.

--- a/README.md
+++ b/README.md
@@ -317,6 +317,8 @@ Query parameters:
 * `limit` Integer. Default: 20. 1-100. If specified, at max this many items are returned.
 * `sort` String. Default: 'new'. In which order the result should be returned. One of: 'new', 'hot'.
 * `cityId` Integer. If specified, returns only posts by users belonging to guilds based in the city with given id.
+* `type` String. If specified, only feed items of that type are returned. One of: 'IMAGE', 'TEXT'.
+* `since` String. ISO-8601 format timestamp. If specified, only feed items created after given timestamp are returned. Note: If no time zone is specified, UTC is assumed.
 
 Examples:
 

--- a/migrations/20170331095601_wilsons_as_function.js
+++ b/migrations/20170331095601_wilsons_as_function.js
@@ -29,6 +29,6 @@ exports.up = function(knex, Promise) {
 
 exports.down = function(knex, Promise) {
   return knex.schema.raw(`
-      DROP FUNCTION wilsons(ups int, downs int)
+      DROP FUNCTION wilsons(ups int, downs int);
     `);
 };

--- a/migrations/20170331095601_wilsons_as_function.js
+++ b/migrations/20170331095601_wilsons_as_function.js
@@ -4,7 +4,7 @@ exports.up = function(knex, Promise) {
       CREATE FUNCTION wilsons(ups int, downs int) RETURNS numeric LANGUAGE plpgsql IMMUTABLE AS $$
       DECLARE
         z numeric;
-        n int;
+        n numeric;
         p numeric;
         l numeric;
         r numeric;

--- a/migrations/20170421095714_top_score_column.js
+++ b/migrations/20170421095714_top_score_column.js
@@ -1,0 +1,12 @@
+
+exports.up = function(knex, Promise) {
+  return knex.schema.table('feed_items', function(table) {
+    table.decimal('top_score').defaultTo(0);
+  });
+};
+
+exports.down = function(knex, Promise) {
+  return knex.schema.table('feed_items', function(table) {
+    table.dropColumn('top_score');
+  });
+}

--- a/migrations/20170421095714_top_score_column.js
+++ b/migrations/20170421095714_top_score_column.js
@@ -1,7 +1,7 @@
 
 exports.up = function(knex, Promise) {
   return knex.schema.table('feed_items', function(table) {
-    table.decimal('top_score').defaultTo(0);
+    table.decimal('top_score', 10, 9).defaultTo(0);
   });
 };
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -8,10 +8,12 @@ const CONST = {
   FEED_SORT_TYPES: {
     NEW: 'new',
     HOT: 'hot',
+    TOP: 'top',
   },
   FEED_SORT_TYPES_ARRAY: [
     'new',
     'hot',
+    'top',
   ],
 };
 

--- a/src/core/feed-core.js
+++ b/src/core/feed-core.js
@@ -65,8 +65,6 @@ function getFeed(opts) {
     limit: 20
   }, opts);
 
-  const sortTop = opts.sort === CONST.FEED_SORT_TYPES.TOP
-
   let sqlString = `
     (SELECT
       feed_items.id as id,
@@ -102,6 +100,7 @@ function getFeed(opts) {
   let params = [opts.client.id];
 
   // TODO: Sticky messages should have their own endpoint
+  const sortTop = opts.sort === CONST.FEED_SORT_TYPES.TOP
   const includeSticky = opts.includeSticky && !opts.beforeId && !sortTop;
   if (includeSticky) {
     sqlString = getStickySqlString(opts.city) + " UNION ALL " + sqlString;

--- a/src/core/feed-core.js
+++ b/src/core/feed-core.js
@@ -294,6 +294,12 @@ function _getWhereSql(opts) {
     params.push(opts.userId);
   }
 
+  if (opts.since) {
+    console.log(opts.since);
+    whereClauses.push(`feed_items.created_at >= ?`);
+    params.push(opts.since);
+  }
+
   return whereClauses.length > 0
     ? knex.raw(` WHERE ${ whereClauses.join(' AND ')}`, params).toString()
     : '';

--- a/src/core/feed-core.js
+++ b/src/core/feed-core.js
@@ -120,6 +120,11 @@ function getFeed(opts) {
   sqlString += ` LIMIT ?`;
   params.push(opts.limit);
 
+  if (opts.after) {
+    sqlString +=  ` OFFSET ?`;
+    params.push(opts.after);
+  }
+
   return knex.raw(sqlString, params)
   .then(result => {
     const rows = result.rows;

--- a/src/core/feed-core.js
+++ b/src/core/feed-core.js
@@ -301,7 +301,6 @@ function _getWhereSql(opts) {
   }
 
   if (opts.since) {
-    console.log(opts.since);
     whereClauses.push(`feed_items.created_at >= ?`);
     params.push(opts.since);
   }

--- a/src/core/feed-core.js
+++ b/src/core/feed-core.js
@@ -52,11 +52,13 @@ function getStickySqlString(city) {
  * @param {number} [opts.limit=20] How many results to return
  * @param {number} [opts.beforeId] Return only items before this feed item
  * @param {number} [opts.city]     Return feed items only from given city
- * @param {string} [opts.sort=new] Either 'hot' or 'new'
+ * @param {string} [opts.sort=new] One of ['hot', 'new', 'top']
  * @param {number} [opts.eventId]  Event whose feed items to return
  * @param {string} [opts.type]     Return only certain type items
  * @param {string} [opts.userId]   Return only certain user's items
  * @param {boolean} [opts.includeSticky = true]   Should sticky messages be included
+ * @param {string} [opts.since]    Limit search to feed items created between 'since' and now.
+ * @param {number} [opts.after]    Offset results by given amount.
  */
 function getFeed(opts) {
   opts = _.merge({
@@ -80,7 +82,7 @@ function getFeed(opts) {
       ${ _getTeamNameSql(opts.city) } as team_name,
       vote_score(feed_items) as votes,
       feed_items.hot_score as hot_score,
-      ${ sortTop ? `COALESCE(top_score.value, 0)` : `0` } as top_score,
+      ${ sortTop ? `COALESCE(top_score.value, 0)` : '0' } as top_score,
       feed_items.is_sticky,
       COALESCE(votes.value, 0) as user_vote
     FROM feed_items
@@ -88,7 +90,7 @@ function getFeed(opts) {
     LEFT JOIN teams ON teams.id = users.team_id
     LEFT JOIN votes ON votes.user_id = ? AND votes.feed_item_id = feed_items.id
     LEFT JOIN cities ON cities.id = teams.city_id
-    ${ sortTop ? _getSortTopSql() : `` }
+    ${ sortTop ? _getSortTopSql() : '' }
     ${ _getWhereSql(opts) }
     GROUP BY
         feed_items.id,

--- a/src/core/feed-core.js
+++ b/src/core/feed-core.js
@@ -57,7 +57,7 @@ function getStickySqlString(city) {
  * @param {string} [opts.userId]   Return only certain user's items
  * @param {boolean} [opts.includeSticky = true]   Should sticky messages be included
  * @param {string} [opts.since]    Limit search to feed items created between 'since' and now.
- * @param {number} [opts.after]    Offset results by given amount.
+ * @param {number} [opts.offset]    Offset results by given amount.
  */
 function getFeed(opts) {
   opts = _.merge({
@@ -111,9 +111,9 @@ function getFeed(opts) {
   sqlString += ` LIMIT ?`;
   params.push(opts.limit);
 
-  if (opts.after) {
+  if (opts.offset) {
     sqlString +=  ` OFFSET ?`;
-    params.push(opts.after);
+    params.push(opts.offset);
   }
 
   return knex.raw(sqlString, params)

--- a/src/core/feed-core.js
+++ b/src/core/feed-core.js
@@ -13,7 +13,6 @@ function getStickySqlString(city) {
     ? ' AND feed_items.city_id IS NULL'
     : knex.raw(` AND (feed_items.city_id = ? OR feed_items.city_id IS NULL)`, city).toString();
 
-  // TODO top_score optimization
   return `
     (SELECT
       feed_items.id as id,
@@ -68,7 +67,6 @@ function getFeed(opts) {
 
   const sortTop = opts.sort === CONST.FEED_SORT_TYPES.TOP
 
-  // TODO top_score optimization
   let sqlString = `
     (SELECT
       feed_items.id as id,
@@ -330,20 +328,6 @@ function _getTeamNameSql(cityId) {
   return !cityId
     ? `teams.name`
     : knex.raw(`CASE WHEN teams.city_id=? THEN teams.name ELSE cities.name END`, [cityId]).toString();
-}
-
-function _getSortTopSql() {
-  return `
-    LEFT JOIN (SELECT
-      votes.feed_item_id as feed_item_id,
-      wilsons(
-        COUNT(CASE votes.value WHEN 1 THEN 1 ELSE NULL END),
-        COUNT(CASE votes.value WHEN -1 THEN 1 ELSE NULL END)
-      ) as value
-      FROM votes
-      GROUP BY votes.feed_item_id
-    ) as top_score ON top_score.feed_item_id = feed_items.id
-  `;
 }
 
 function _resolveAuthorType(row, client) {

--- a/src/core/score-core.js
+++ b/src/core/score-core.js
@@ -1,6 +1,5 @@
 const {knex} = require('../util/database').connect();
 const requireEnvs = require('../util/require-envs');
-
 requireEnvs(['FEED_ZERO_TIME', 'FEED_INFLATION_INTERVAL', 'FEED_BASE_LOG']);
 
 const BASE_LOG = Math.log(process.env.FEED_BASE_LOG);

--- a/src/core/score-core.js
+++ b/src/core/score-core.js
@@ -22,19 +22,19 @@ function hotScore(votes, createdAt) {
 
 function updateTopScores() {
   const updateSql = `
-  UPDATE feed_items
-  SET top_score = top_scores.value
-  FROM
-    (SELECT
-      feed_item_id,
-      wilsons(
-        COUNT(CASE votes.value WHEN 1 THEN 1 ELSE null END)::int,
-        COUNT(CASE votes.value WHEN -1 THEN 1 ELSE null END)::int
-      ) AS value
-    FROM votes
-    GROUP BY votes.feed_item_id
-    ) AS top_scores
-  WHERE feed_items.id = top_scores.feed_item_id
+    UPDATE feed_items
+    SET top_score = top_scores.value
+    FROM
+      (SELECT
+        feed_item_id,
+        wilsons(
+          COUNT(CASE votes.value WHEN 1 THEN 1 ELSE null END)::int,
+          COUNT(CASE votes.value WHEN -1 THEN 1 ELSE null END)::int
+        ) AS value
+      FROM votes
+      GROUP BY votes.feed_item_id
+      ) AS top_scores
+    WHERE feed_items.id = top_scores.feed_item_id
   `;
 
   return knex.raw(updateSql);

--- a/src/core/vote-core.js
+++ b/src/core/vote-core.js
@@ -1,5 +1,5 @@
 const {knex} = require('../util/database').connect();
-import {hotScore} from './hot-score';
+import {hotScore} from './score-core';
 
 function createOrUpdateVote(opts) {
   const updateVoteSql = `

--- a/src/http/feed-http.js
+++ b/src/http/feed-http.js
@@ -12,7 +12,7 @@ const getFeed = createJsonRoute(function(req, res) {
     sort: req.query.sort,
     type: req.query.type,
     since: req.query.since,
-    after: req.query.after,
+    offset: req.query.offset,
   }, 'feedParams');
 
   const coreParams = _.merge(feedParams, {

--- a/src/http/feed-http.js
+++ b/src/http/feed-http.js
@@ -10,6 +10,7 @@ const getFeed = createJsonRoute(function(req, res) {
     limit: req.query.limit,
     city: req.query.cityId,
     sort: req.query.sort,
+    type: req.query.type,
   }, 'feedParams');
 
   const coreParams = _.merge(feedParams, {

--- a/src/http/feed-http.js
+++ b/src/http/feed-http.js
@@ -12,6 +12,7 @@ const getFeed = createJsonRoute(function(req, res) {
     sort: req.query.sort,
     type: req.query.type,
     since: req.query.since,
+    after: req.query.after,
   }, 'feedParams');
 
   const coreParams = _.merge(feedParams, {

--- a/src/http/feed-http.js
+++ b/src/http/feed-http.js
@@ -11,6 +11,7 @@ const getFeed = createJsonRoute(function(req, res) {
     city: req.query.cityId,
     sort: req.query.sort,
     type: req.query.type,
+    since: req.query.since,
   }, 'feedParams');
 
   const coreParams = _.merge(feedParams, {

--- a/src/validation/index.js
+++ b/src/validation/index.js
@@ -41,7 +41,7 @@ const schemas = {
     beforeId: Joi.number().integer().min(0).optional(),
     limit: Joi.number().integer().min(1).max(100).optional(),
     since: Joi.date().iso(),
-    after: Joi.number().integer().min(0),
+    offset: Joi.number().integer().min(0),
     type: Joi.string()
       .valid(['TEXT', 'IMAGE'])
       .optional(),

--- a/src/validation/index.js
+++ b/src/validation/index.js
@@ -40,6 +40,7 @@ const schemas = {
     city: common.primaryKeyId,
     beforeId: Joi.number().integer().min(0).optional(),
     limit: Joi.number().integer().min(1).max(100).optional(),
+    since: Joi.date().iso(),
     type: Joi.string()
       .valid(['TEXT', 'IMAGE'])
       .optional(),

--- a/src/validation/index.js
+++ b/src/validation/index.js
@@ -41,6 +41,7 @@ const schemas = {
     beforeId: Joi.number().integer().min(0).optional(),
     limit: Joi.number().integer().min(1).max(100).optional(),
     since: Joi.date().iso(),
+    after: Joi.number().integer().min(0),
     type: Joi.string()
       .valid(['TEXT', 'IMAGE'])
       .optional(),

--- a/src/validation/index.js
+++ b/src/validation/index.js
@@ -40,6 +40,9 @@ const schemas = {
     city: common.primaryKeyId,
     beforeId: Joi.number().integer().min(0).optional(),
     limit: Joi.number().integer().min(1).max(100).optional(),
+    type: Joi.string()
+      .valid(['TEXT', 'IMAGE'])
+      .optional(),
     sort: Joi.string()
       .valid(CONST.FEED_SORT_TYPES_ARRAY)
       .default(CONST.FEED_SORT_TYPES.NEW)

--- a/src/worker/update-top-scores.js
+++ b/src/worker/update-top-scores.js
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+import * as scoreCore from '../core/score-core';
+const logger = require('../util/logger')(__filename);
+
+
+_updateBiases()
+.then(() => {
+  logger.info('Finished updating top_scores');
+  process.exit();
+})
+.catch(err => {
+  logger.error('Updating top_scores errored', err);
+  process.exit(1);
+});
+
+function _updateBiases() {
+  logger.info('Beginning top_score update');
+  return scoreCore.updateTopScores();
+}


### PR DESCRIPTION
- Added feed top sorting. Feed item is assigned a top_score based on votes given. The ranking isn't real time and there is a worker that needs to be scheduled. This is in order to have faster table lookups.
- New query parameters `type`, `since` and `after` for endpoint `/feed`.
  - `since` is a ISO-8601 format date and limits the search to feed_items created between `since` and now.
  - `after` is an integer type which defines the offset of the results. Useful for when sorting type is set to `top`. 
  - `type` defines the type of returned feed_items. Internally already supported, but now exposed to clients as well.
- Renamed `hot-score.js` to `score-core.js`
- Some code clean up.
